### PR TITLE
fix: E11000 duplicate key error when creating timeout retry task

### DIFF
--- a/src/taskSchema.js
+++ b/src/taskSchema.js
@@ -175,9 +175,19 @@ taskSchema.statics.expireTimedOutTasks = async function expireTimedOutTasks() {
     }
 
     if (task.retryOnTimeoutCount > 0) {
+      // Copy task data but remove _id so MongoDB generates a new one
+      const taskData = task.toObject({ virtuals: false });
+      delete taskData._id;
       await Task.create({
-        ...task.toObject({ virtuals: false }),
+        ...taskData,
         status: 'pending',
+        retryOnTimeoutCount: task.retryOnTimeoutCount - 1,
+        startedRunningAt: null,
+        finishedRunningAt: null,
+        workerName: null,
+        error: null,
+        result: null,
+        timeoutAt: null,
         schedulingTimeoutAt: now.valueOf() + 10 * 60 * 1000
       });
     } else {


### PR DESCRIPTION
## Problem

When a task times out and has `retryOnTimeoutCount > 0`, the `expireTimedOutTasks()` function creates a retry task by spreading `task.toObject({ virtuals: false })`. This includes the `_id` field from the original task, causing MongoDB to throw an `E11000 duplicate key error` when trying to insert the retry task.

```
MongoServerError: E11000 duplicate key error collection: db.tasks index: _id_ dup key: { _id: ObjectId('...') }
```

## Solution

1. Copy the task data and delete the `_id` field before creating the retry task, allowing MongoDB to generate a new `_id`
2. Decrement `retryOnTimeoutCount` so retries are properly limited (without this, the retry task would have the same count and retry indefinitely)
3. Reset execution state fields (`startedRunningAt`, `error`, `result`, etc.) so the retry task starts fresh

## Changes

```javascript
// Before (buggy)
if (task.retryOnTimeoutCount > 0) {
  await Task.create({
    ...task.toObject({ virtuals: false }),
    status: 'pending',
    schedulingTimeoutAt: now.valueOf() + 10 * 60 * 1000
  });
}

// After (fixed)
if (task.retryOnTimeoutCount > 0) {
  const taskData = task.toObject({ virtuals: false });
  delete taskData._id;
  await Task.create({
    ...taskData,
    status: 'pending',
    retryOnTimeoutCount: task.retryOnTimeoutCount - 1,
    startedRunningAt: null,
    finishedRunningAt: null,
    workerName: null,
    error: null,
    result: null,
    timeoutAt: null,
    schedulingTimeoutAt: now.valueOf() + 10 * 60 * 1000
  });
}
```