### PR TITLE
Always filter polled tasks by registered handler names and simplify tests

### DIFF
--- a/test/task.test.js
+++ b/test/task.test.js
@@ -220,9 +220,9 @@ describe('Task', function() {
     const unhandledTask = await Task.findOne({ name: 'unhandledJob' });
     assert.ok(unhandledTask);
     assert.equal(unhandledTask.status, 'pending');
-    assert.strictEqual(unhandledTask.startedRunningAt, null);
-    assert.strictEqual(unhandledTask.timeoutAt, null);
-    assert.strictEqual(unhandledTask.workerName, null);
+    assert.strictEqual(unhandledTask.startedRunningAt, undefined);
+    assert.strictEqual(unhandledTask.timeoutAt, undefined);
+    assert.strictEqual(unhandledTask.workerName, undefined);
   });
 
 


### PR DESCRIPTION
### Motivation
- Ensure the poll loop never claims tasks that have no registered handler to avoid executing unhandleable tasks. 
- Remove the previous handler-count special-casing and in-memory skip lists which complicated polling behavior. 
- Simplify test surface by removing the obsolete ">250 handlers" check now that polling always filters by registered handlers.

### Description
- Constrain `poll()` claims by building `registeredHandlerNames` from `this._handlers` and adding `name: { $in: registeredHandlerNames }` to the query filter so only tasks with registered handlers are claimed. 
- Harden `execute()` to return `null` when `this._handlers` is unset or when there is no handler for `task.name`. 
- Simplify tests in `test/task.test.js` by removing the `>250 handlers` case and renaming the remaining test to `poll() filters by handler names` to reflect the current behavior.

### Testing
- Ran `npm run lint`, which completed successfully. 
- Ran `npm test` (Mocha); the test suite did not complete because Mocha hooks timed out due to the local MongoDB at `mongodb://localhost:27017/task_test` being unreachable in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698df2c6032c8324afe31991cac4d074)